### PR TITLE
Feature/bulk create and names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>jakarta.validation</groupId>
+                        <artifactId>jakarta.validation-api</artifactId>
+                        <version>3.0.2</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.hibernate.validator</groupId>
+                        <artifactId>hibernate-validator</artifactId>
+                        <version>8.0.0.Final</version>
+                </dependency>
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>

--- a/src/main/java/com/meraphorce/controllers/BulkController.java
+++ b/src/main/java/com/meraphorce/controllers/BulkController.java
@@ -1,0 +1,64 @@
+package com.meraphorce.controllers;
+
+import com.meraphorce.dto.StatusResponse;
+import com.meraphorce.dto.UserRequest;
+import com.meraphorce.mappers.impl.UserMapper;
+import com.meraphorce.services.UserService;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Path;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/bulk")
+public class BulkController
+{
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserMapper mapper;
+
+    @Autowired
+    private Validator validator;
+
+    @PostMapping("/users")
+    public ResponseEntity<List<StatusResponse>> createUsersInBulk(@NotEmpty @RequestBody
+                                                                  List<UserRequest> users) {
+        return ResponseEntity.ok(users.stream().map(user -> {
+                    Set<ConstraintViolation<UserRequest>> violations = validator.validate(user);
+                    if ( violations.isEmpty() ) {
+                        userService.createUser(mapper.requestToEntity(user));
+                        return StatusResponse.builder()
+                            .status(HttpStatus.OK)
+                            .message(String.format("New user with name=%s created", user.getName()))
+                            .build();
+                    } else {
+                        StringJoiner joiner = new StringJoiner(", ");
+                        for ( ConstraintViolation<UserRequest> constraintViolation : violations ) {
+                            joiner.add(String.format("%s: %s", getFieldName(constraintViolation),
+                                                     constraintViolation.getMessage()));
+                        }
+                        return StatusResponse.builder()
+                            .status(HttpStatus.BAD_REQUEST).message(joiner.toString())
+                            .build();
+                    }
+                }).collect(Collectors.toList()));
+    }
+
+    private String getFieldName(ConstraintViolation violation) {
+        String field = null;
+        for (Path.Node node : violation.getPropertyPath()) {
+            field = node.getName();
+        }
+        return field;
+    }
+}

--- a/src/main/java/com/meraphorce/controllers/BulkController.java
+++ b/src/main/java/com/meraphorce/controllers/BulkController.java
@@ -3,22 +3,15 @@ package com.meraphorce.controllers;
 import com.meraphorce.dto.StatusResponse;
 import com.meraphorce.dto.UserRequest;
 import com.meraphorce.mappers.impl.UserMapper;
-import com.meraphorce.services.UserAlreadyExistsException;
 import com.meraphorce.services.UserService;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Path;
-import jakarta.validation.Validator;
+import jakarta.validation.constraints.Size;
 import java.util.List;
-import java.util.Set;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-
 
 @RestController
 @RequestMapping("/bulk")
@@ -30,45 +23,9 @@ public class BulkController
     @Autowired
     private UserMapper mapper;
 
-    @Autowired
-    private Validator validator;
-
     @PostMapping("/users")
-    public ResponseEntity<List<StatusResponse>> createUsersInBulk(@NotEmpty @RequestBody
-                                                                  List<UserRequest> users) {
-        return ResponseEntity.ok(users.stream().map(user -> {
-                    Set<ConstraintViolation<UserRequest>> violations = validator.validate(user);
-                    if ( violations.isEmpty() ) {
-                        try {
-                            userService.createUser(mapper.requestToEntity(user));
-                            return StatusResponse.builder()
-                                .status(HttpStatus.OK.value())
-                                .message(String.format("New user with name=%s created", user.getName()))
-                                .build();
-                        } catch ( UserAlreadyExistsException ex ) {
-                            return StatusResponse.builder()
-                                .status(HttpStatus.BAD_REQUEST.value())
-                                .message(ex.getMessage())
-                                .build();
-                        }
-                    } else {
-                        StringJoiner joiner = new StringJoiner(", ");
-                        for ( ConstraintViolation<UserRequest> constraintViolation : violations ) {
-                            joiner.add(String.format("%s: %s", getFieldName(constraintViolation),
-                                                     constraintViolation.getMessage()));
-                        }
-                        return StatusResponse.builder()
-                            .status(HttpStatus.BAD_REQUEST.value()).message(joiner.toString())
-                            .build();
-                    }
-                }).collect(Collectors.toList()));
-    }
-
-    private String getFieldName(ConstraintViolation violation) {
-        String field = null;
-        for (Path.Node node : violation.getPropertyPath()) {
-            field = node.getName();
-        }
-        return field;
+    public ResponseEntity<List<StatusResponse>> createUsersInBulk(@NotEmpty @Size(min=1, max=100)
+                                                                  @RequestBody List<UserRequest> users) {
+        return ResponseEntity.ok(userService.createUsersInBulk(users));
     }
 }

--- a/src/main/java/com/meraphorce/controllers/UserController.java
+++ b/src/main/java/com/meraphorce/controllers/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,7 +24,7 @@ public class UserController
     private UserMapper mapper;
 
     @PostMapping
-    public ResponseEntity<UserResponse> createUser(@RequestBody UserRequest user) {
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody UserRequest user) {
         return ResponseEntity.ok(mapper.entityToResponse(userService
                                                          .createUser(mapper.requestToEntity(user))));
     }
@@ -42,7 +43,7 @@ public class UserController
 
     @PutMapping("/{id}")
     public ResponseEntity<UserResponse> updateUser(@PathVariable String id,
-                                                   @RequestBody UserRequest userRequest) {
+                                                   @Valid @RequestBody UserRequest userRequest) {
         return ResponseEntity
             .ok(mapper.entityToResponse(userService
                                         .updateUser(id, mapper.requestToEntity(userRequest))));

--- a/src/main/java/com/meraphorce/controllers/UserController.java
+++ b/src/main/java/com/meraphorce/controllers/UserController.java
@@ -3,15 +3,13 @@ package com.meraphorce.controllers;
 import com.meraphorce.dto.UserResponse;
 import com.meraphorce.dto.UserRequest;
 import com.meraphorce.mappers.impl.UserMapper;
-import com.meraphorce.models.User;
 import com.meraphorce.services.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")

--- a/src/main/java/com/meraphorce/controllers/UserController.java
+++ b/src/main/java/com/meraphorce/controllers/UserController.java
@@ -2,6 +2,7 @@ package com.meraphorce.controllers;
 
 import com.meraphorce.dto.UserResponse;
 import com.meraphorce.dto.UserRequest;
+import com.meraphorce.mappers.impl.UserMapper;
 import com.meraphorce.models.User;
 import com.meraphorce.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/users")
@@ -17,25 +19,33 @@ public class UserController
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private UserMapper mapper;
+
     @PostMapping
-    public ResponseEntity<UserResponse> createUser(@RequestBody UserRequest user){
-        return ResponseEntity.ok(userService.createUser(user));
+    public ResponseEntity<UserResponse> createUser(@RequestBody UserRequest user) {
+        return ResponseEntity.ok(mapper.entityToResponse(userService
+                                                         .createUser(mapper.requestToEntity(user))));
     }
 
     @GetMapping
-    public ResponseEntity<List<UserResponse>> getAllUsers(){
-        return ResponseEntity.ok(userService.getAllUsers());
+    public ResponseEntity<List<UserResponse>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers().stream()
+                                 .map(mapper::entityToResponse)
+                                 .collect(Collectors.toList()));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<UserResponse> getUserById(@PathVariable String id) {
-        return ResponseEntity.ok(userService.getUserById(id));
+        return ResponseEntity.ok(mapper.entityToResponse(userService.getUserById(id)));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<UserResponse> updateUser(@PathVariable String id,
                                                    @RequestBody UserRequest userRequest) {
-        return ResponseEntity.ok(userService.updateUser(id, userRequest));
+        return ResponseEntity
+            .ok(mapper.entityToResponse(userService
+                                        .updateUser(id, mapper.requestToEntity(userRequest))));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/meraphorce/controllers/UserController.java
+++ b/src/main/java/com/meraphorce/controllers/UserController.java
@@ -52,4 +52,9 @@ public class UserController
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/names")
+    public ResponseEntity<List<String>> getNames() {
+        return ResponseEntity.ok(userService.getNames());
+    }
 }

--- a/src/main/java/com/meraphorce/dto/StatusResponse.java
+++ b/src/main/java/com/meraphorce/dto/StatusResponse.java
@@ -1,0 +1,19 @@
+package com.meraphorce.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class StatusResponse {
+    private HttpStatus status;
+    private String message;
+}

--- a/src/main/java/com/meraphorce/dto/StatusResponse.java
+++ b/src/main/java/com/meraphorce/dto/StatusResponse.java
@@ -14,6 +14,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Setter
 public class StatusResponse {
-    private HttpStatus status;
+    private int status;
     private String message;
 }

--- a/src/main/java/com/meraphorce/dto/StatusResponse.java
+++ b/src/main/java/com/meraphorce/dto/StatusResponse.java
@@ -1,6 +1,5 @@
 package com.meraphorce.dto;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +13,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Setter
 public class StatusResponse {
-    private int status;
+    private Boolean created;
     private String message;
 }

--- a/src/main/java/com/meraphorce/dto/UserRequest.java
+++ b/src/main/java/com/meraphorce/dto/UserRequest.java
@@ -1,4 +1,9 @@
 package com.meraphorce.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Email;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +16,12 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UserRequest {
-    private String id;
+    @NotEmpty(message = "Can't be empty")
+    @NotNull(message = "Can't be null")
     private String name;
+
+    @NotEmpty(message = "Can't be empty")
+    @NotNull(message = "Can't be null")
+    @Email
     private String email;
 }

--- a/src/main/java/com/meraphorce/mappers/impl/UserMapper.java
+++ b/src/main/java/com/meraphorce/mappers/impl/UserMapper.java
@@ -21,7 +21,6 @@ public class UserMapper implements MapperI<User, UserResponse, UserRequest>
     @Override
     public User requestToEntity(UserRequest request) {
         return User.builder()
-            .id(request.getId())
             .name(request.getName())
             .email(request.getEmail())
             .build();
@@ -39,7 +38,6 @@ public class UserMapper implements MapperI<User, UserResponse, UserRequest>
     @Override
     public UserRequest entityToRequest(User entity) {
         return UserRequest.builder()
-            .id(entity.getId())
             .name(entity.getName())
             .email(entity.getEmail())
             .build();

--- a/src/main/java/com/meraphorce/processors/UserBulkProcessor.java
+++ b/src/main/java/com/meraphorce/processors/UserBulkProcessor.java
@@ -1,0 +1,61 @@
+package com.meraphorce.processors;
+
+import com.meraphorce.dto.StatusResponse;
+import com.meraphorce.dto.UserRequest;
+import com.meraphorce.mappers.impl.UserMapper;
+import com.meraphorce.models.User;
+import com.meraphorce.services.UserAlreadyExistsException;
+import com.meraphorce.respositories.UserRepository;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Processor for handling operations in bulk of users.
+ */
+@Component
+@Validated
+public class UserBulkProcessor {
+
+    private final UserRepository repository;
+    private final UserMapper mapper;
+
+    /**
+     * Constructs a new UserBulkProcessor with the specified UserRepository and UserMapper.
+     *
+     * @param repository the repository for accessing user data
+     * @param mapper the mapper for converting between UserRequest and User entities
+     * @param validator the Jakarta Bean Validation validator
+     */
+    @Autowired
+    public UserBulkProcessor(UserRepository repository, UserMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    // private String getViolationFieldName(ConstraintViolation violation) {
+    //     String field = null;
+    //     for (Path.Node node : violation.getPropertyPath()) {
+    //         field = node.getName();
+    //     }
+    //     return field;
+    // }
+
+    /**
+     * Processes a single user by creating a new user entity in the repository.
+     * Throws UserAlreadyExistsException if a user with the same email already exists.
+     *
+     * @param request the UserRequest object representing the user to be created
+     * @throws UserAlreadyExistsException if a user with the given email already exists
+     */
+    public void processUser(@Valid UserRequest request) {
+        if ( repository.existsByEmail(request.getEmail()) )
+            throw new UserAlreadyExistsException(String.format("User with email = %s already exists",
+                                                               request.getEmail()));
+        User user = mapper.requestToEntity(request);
+        user.setId(UUID.randomUUID().toString());
+        repository.save(user);
+    }
+}

--- a/src/main/java/com/meraphorce/respositories/UserRepository.java
+++ b/src/main/java/com/meraphorce/respositories/UserRepository.java
@@ -11,5 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, String>{
     @Query("select u.name from User u")
     List<String> findNames();
-    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/meraphorce/respositories/UserRepository.java
+++ b/src/main/java/com/meraphorce/respositories/UserRepository.java
@@ -1,9 +1,13 @@
 package com.meraphorce.respositories;
 
+import java.util.List;
 import com.meraphorce.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, String>{
+    @Query("select u.name from User u")
+    List<String> findNames();
 }

--- a/src/main/java/com/meraphorce/respositories/UserRepository.java
+++ b/src/main/java/com/meraphorce/respositories/UserRepository.java
@@ -1,6 +1,7 @@
 package com.meraphorce.respositories;
 
 import java.util.List;
+import java.util.Optional;
 import com.meraphorce.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, String>{
     @Query("select u.name from User u")
     List<String> findNames();
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/meraphorce/services/UserService.java
+++ b/src/main/java/com/meraphorce/services/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -15,6 +16,10 @@ public class UserService
     private UserRepository userRepository;
 
     public User createUser(User user) {
+        Optional<User> userOpt = userRepository.findByEmail(user.getEmail());
+        if ( userOpt.isPresent() )
+            throw new UserAlreadyExistsException(String.format("A user with email=%s already exists.",
+                                                               user.getEmail()));
         user.setId(UUID.randomUUID().toString());
         return userRepository.save(user);
     }

--- a/src/main/java/com/meraphorce/services/UserService.java
+++ b/src/main/java/com/meraphorce/services/UserService.java
@@ -1,15 +1,11 @@
 package com.meraphorce.services;
 
-import com.meraphorce.dto.UserResponse;
-import com.meraphorce.dto.UserRequest;
 import com.meraphorce.models.User;
 import com.meraphorce.respositories.UserRepository;
-import com.meraphorce.mappers.impl.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class UserService
@@ -17,25 +13,19 @@ public class UserService
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserMapper mapper;
-
-    public UserResponse createUser(UserRequest user) {
+    public User createUser(User user) {
         if ( userRepository.existsById(user.getId()) )
             throw new UserAlreadyExistsException(String.format("User with id=%s already exists",
                                                                user.getId()));
-        return mapper.entityToResponse(userRepository.save(mapper.requestToEntity(user)));
+        return userRepository.save(user);
     }
 
-    public List<UserResponse> getAllUsers() {
-        return userRepository.findAll().stream()
-            .map(mapper::entityToResponse)
-            .collect(Collectors.toList());
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
     }
 
-    public UserResponse getUserById(String id) {
+    public User getUserById(String id) {
         return userRepository.findById(id)
-            .map(mapper::entityToResponse)
             .orElseThrow(() -> new ResourceNotFoundException(String.format("User with id=%s not found",
                                                                            id)));
     }
@@ -47,11 +37,10 @@ public class UserService
         userRepository.delete(user);
     }
 
-    public UserResponse updateUser(String id, UserRequest request) {
+    public User updateUser(String id, User request) {
         if ( ! userRepository.existsById(id) )
             throw new ResourceNotFoundException(String.format("User with id=%s not found", id));
-        User user = mapper.requestToEntity(request);
-        user.setId(id);
-        return mapper.entityToResponse(userRepository.save(user));
+        request.setId(id);
+        return userRepository.save(request);
     }
 }

--- a/src/main/java/com/meraphorce/services/UserService.java
+++ b/src/main/java/com/meraphorce/services/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class UserService
@@ -14,9 +15,7 @@ public class UserService
     private UserRepository userRepository;
 
     public User createUser(User user) {
-        if ( userRepository.existsById(user.getId()) )
-            throw new UserAlreadyExistsException(String.format("User with id=%s already exists",
-                                                               user.getId()));
+        user.setId(UUID.randomUUID().toString());
         return userRepository.save(user);
     }
 

--- a/src/main/java/com/meraphorce/services/UserService.java
+++ b/src/main/java/com/meraphorce/services/UserService.java
@@ -42,4 +42,8 @@ public class UserService
         request.setId(id);
         return userRepository.save(request);
     }
+
+    public List<String> getNames() {
+        return userRepository.findNames();
+    }
 }

--- a/src/main/java/com/meraphorce/services/UserService.java
+++ b/src/main/java/com/meraphorce/services/UserService.java
@@ -1,54 +1,79 @@
 package com.meraphorce.services;
 
+import com.meraphorce.dto.StatusResponse;
+import com.meraphorce.dto.UserRequest;
 import com.meraphorce.models.User;
+import com.meraphorce.processors.UserBulkProcessor;
 import com.meraphorce.respositories.UserRepository;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class UserService
 {
+    private final UserRepository repository;
+    private final UserBulkProcessor processor;
+
     @Autowired
-    private UserRepository userRepository;
+    public UserService(UserRepository repository, UserBulkProcessor processor) {
+        this.repository = repository;
+        this.processor = processor;
+    }
 
     public User createUser(User user) {
-        Optional<User> userOpt = userRepository.findByEmail(user.getEmail());
-        if ( userOpt.isPresent() )
+        if ( repository.existsByEmail(user.getEmail()) )
             throw new UserAlreadyExistsException(String.format("A user with email=%s already exists.",
                                                                user.getEmail()));
         user.setId(UUID.randomUUID().toString());
-        return userRepository.save(user);
+        return repository.save(user);
+    }
+
+    public List<StatusResponse> createUsersInBulk(List<UserRequest> users) {
+        return users.stream().map(request -> {
+                try {
+                    processor.processUser(request);
+                    return StatusResponse.builder().created(true)
+                        .message(String.format("New user with name=%s created", request.getName()))
+                        .build();
+                } catch ( UserAlreadyExistsException | ConstraintViolationException ex ) {
+                    return StatusResponse.builder().created(false).message(ex.getMessage()).build();
+                } catch ( Exception ex ) {
+                    return StatusResponse.builder().created(false)
+                        .message(String.format("An unexpected error occurred: %s", ex.getMessage()))
+                        .build();
+                }
+            }).collect(Collectors.toList());
     }
 
     public List<User> getAllUsers() {
-        return userRepository.findAll();
+        return repository.findAll();
     }
 
     public User getUserById(String id) {
-        return userRepository.findById(id)
+        return repository.findById(id)
             .orElseThrow(() -> new ResourceNotFoundException(String.format("User with id=%s not found",
                                                                            id)));
     }
 
     public void deleteUser(String id) {
-        User user = userRepository.findById(id)
+        User user = repository.findById(id)
             .orElseThrow(() -> new ResourceNotFoundException(String.format("User with id=%s not found",
                                                                            id)));
-        userRepository.delete(user);
+        repository.delete(user);
     }
 
     public User updateUser(String id, User request) {
-        if ( ! userRepository.existsById(id) )
+        if ( ! repository.existsById(id) )
             throw new ResourceNotFoundException(String.format("User with id=%s not found", id));
         request.setId(id);
-        return userRepository.save(request);
+        return repository.save(request);
     }
 
     public List<String> getNames() {
-        return userRepository.findNames();
+        return repository.findNames();
     }
 }


### PR DESCRIPTION
### Overview
This pull request introduces two new endpoints:
1.  `/bulk/users` to create users in bulk.
2.  `/users/names` to get de names of all users.

In addition:
1. The DTO mapper is now called from the controllers and not from the service.
2. When creating users, it is verified that there is no user with the same email address as the one we are trying to create.
3. The id of the user is now a UUID code.

### Changes

- New dependencies:
  1. jakarta.validation-api
  2. hibernate-validator
- New classes:
  1. `dto.StatusResponse`
  3. `controllers.BulkController`
- New methods in `UserRepository`:
  1. `findNames`
  2. `findByEmail`
- New method in `UserService`:
  1. `getNames`
- New method in `UserController`:
  1. `getNames`
 